### PR TITLE
ENH: Added the ability to specify a customization_id.  

### DIFF
--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -28,7 +28,7 @@ var qs = require('../util/querystring.js');
 var OPENING_MESSAGE_PARAMS_ALLOWED = ['continuous', 'max_alternatives', 'timestamps', 'word_confidence', 'inactivity_timeout',
   'content-type', 'interim_results', 'keywords', 'keywords_threshold', 'word_alternatives_threshold', 'profanity_filter', 'smart_formatting'];
 
-var QUERY_PARAMS_ALLOWED = ['model', 'watson-token']; // , 'X-Watson-Learning-Opt-Out' - should be allowed but currently isn't due to a service bug
+var QUERY_PARAMS_ALLOWED = ['customization_id',' model', 'watson-token']; // , 'X-Watson-Learning-Opt-Out' - should be allowed but currently isn't due to a service bug
 
 
 /**

--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -174,7 +174,8 @@ RecognizeStream.prototype.initialize = function() {
     options['X-Watson-Learning-Opt-Out'] = options['X-WDC-PL-OPT-OUT'];
   }
 
-  var queryParams = util._extend({model: 'en-US_BroadbandModel'}, pick(options, QUERY_PARAMS_ALLOWED));
+  var queryParams=util._extend('customization_id' in options ? pick(options, QUERY_PARAMS_ALLOWED):{model: 'en-US_BroadbandModel'}, pick(options, QUERY_PARAMS_ALLOWED));
+
   var queryString = qs.stringify(queryParams);
   var url = (options.url || 'wss://stream.watsonplatform.net/speech-to-text/api').replace(/^http/, 'ws') + '/v1/recognize?' + queryString;
 


### PR DESCRIPTION
The library should support the use of a customization_id when present and not use the model parameter.  The customization_id corresponds to a trained language model that should be used over a specified model name.