### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,9 @@ IBM Watson Speech Services for Web Browsers
 Allows you to easily add voice recognition and synthesis to any web app with minimal code.
 
 ### Built for Browsers
-This library is primarily intended for use in web browsers.
-Check out [watson-developer-cloud](https://www.npmjs.com/package/watson-developer-cloud) to use Watson services (speech and others) from Node.js.
+This library is primarily intended for use in web browsers. Check out [watson-developer-cloud](https://www.npmjs.com/package/watson-developer-cloud) to use Watson services (speech and others) from Node.js.
 
-However, a **server-side component is required to generate auth tokens**. 
-The examples/ folder includes example Node.js and Python servers, and SDKs are available for [Node.js](https://github.com/watson-developer-cloud/node-sdk#authorization), 
-[Java](https://github.com/watson-developer-cloud/java-sdk), 
-[Python](https://github.com/watson-developer-cloud/python-sdk/blob/master/examples/authorization_v1.py), 
-and there is also a [REST API](http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-tokens.shtml).
+However, a **server-side component is required to generate auth tokens**. The examples/ folder includes example Node.js and Python servers, and SDKs are available for [Node.js](https://github.com/watson-developer-cloud/node-sdk#authorization), [Java](https://github.com/watson-developer-cloud/java-sdk), [Python](https://github.com/watson-developer-cloud/python-sdk/blob/master/examples/authorization_v1.py), and there is also a [REST API](https://www.ibm.com/watson/developercloud/doc/common/getting-started-tokens.html).
 
 
 ### Installation - standalone

--- a/examples/readme.md
+++ b/examples/readme.md
@@ -10,7 +10,7 @@ There are also a few audio files to test with in the `static/` folder.
 Prerequisite
 ------------
 
-* IBM Watson Speech to Text service credentials - see http://www.ibm.com/watson/developercloud/doc/getting_started/gs-credentials.shtml
+* IBM Watson Speech to Text service credentials - see [Service credentials for Watson services](https://www.ibm.com/watson/developercloud/doc/common/getting-started-credentials.html)
 * Node.js OR Python
 * [Bower](https://bower.io/) for installing client-side dependencies
 
@@ -37,17 +37,9 @@ Setup - Python
 Notes
 -----
 
-* The examples all use [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (a modern promise-based replacement for XMLHttpRequest) to retrieve auth tokens. 
-  Most supported browsers include a native fetch implementation, but a pollyfill is included in the top-level module for older browsers.
-* The examples use a Node.js server to generate tokens. It doesn't have to be written in Node.js, but *some server-side token generator is required*. 
-  The SDK will not accept your service credentials directly, and you can not use them to generate a token client-side. 
-  SDKs are available for [Node.js](https://github.com/watson-developer-cloud/node-sdk#authorization), 
-  [Java](https://github.com/watson-developer-cloud/java-sdk), 
-  [Python](https://github.com/watson-developer-cloud/python-sdk/blob/master/examples/authorization_v1.py), 
-  and there is a [REST API](http://www.ibm.com/smarterplanet/us/en/ibmwatson/developercloud/doc/getting_started/gs-tokens.shtml) 
-  for use with other languages (or `curl`).
-* The Speech SDK may be used in browserify, Webpack, or as a standalone library.
-  Most of the examples use the standalone version either installed via bower or symlinked to the root directory when developing locally.
+* The examples all use [fetch](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) (a modern promise-based replacement for XMLHttpRequest) to retrieve auth tokens. Most supported browsers include a native fetch implementation, but a pollyfill is included in the top-level module for older browsers.
+* The examples use a Node.js server to generate tokens. It doesn't have to be written in Node.js, but *some server-side token generator is required*. The SDK will not accept your service credentials directly, and you can not use them to generate a token client-side. SDKs are available for [Node.js](https://github.com/watson-developer-cloud/node-sdk#authorization), [Java](https://github.com/watson-developer-cloud/java-sdk), [Python](https://github.com/watson-developer-cloud/python-sdk/blob/master/examples/authorization_v1.py), and there is a [REST API](https://www.ibm.com/watson/developercloud/doc/common/getting-started-tokens.html) for use with other languages (or `curl`).
+* The Speech SDK may be used in browserify, Webpack, or as a standalone library. Most of the examples use the standalone version either installed via bower or symlinked to the root directory when developing locally.
 
 
 More Examples


### PR DESCRIPTION
- getting_started content moved with migration to Markdown
- also removed new lines within paragraphs.