### PR TITLE
remove continuous from OPENING_MESSAGE_PARAMS_ALLOWED

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ examples/node_modules/
 dist/*.js
 examples/static/bower_components/
 gh-pages/
+.idea

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ There have been a few breaking changes in recent releases:
 * Changed format of objects emitted in objectMode to exactly match what service sends. Added `ResultStream` class and `extract_results` option to enable older behavior.
 * Changed `playback-error` event to just `error` when recognizing and playing a file. Check for `error.name == 'UNSUPPORTED_FORMAT'` to identify playback errors. This error is special in that it does not stop the streaming of results.
 * Renamed `recognizeFile()`'s `data` option to `file` because it now may be a URL. Using a URL enables faster playback and mobile Safari support
+* Continous flag for OPENING_MESSAGE_PARAMS_ALLOWED has been removed
 
 See [CHANGELOG.md](CHANGELOG.md) for a complete list of changes.
 

--- a/examples/static/microphone-streaming-auto-stop.html
+++ b/examples/static/microphone-streaming-auto-stop.html
@@ -34,8 +34,15 @@ document.querySelector('#button').onclick = function () {
 
       var stream = WatsonSpeech.SpeechToText.recognizeMicrophone({
         token: token,
-        continuous: false, // false = automatically stop transcription the first time a pause is detected
+//        continuous: false, // no longer supported
         outputElement: '#output' // CSS selector or DOM Element
+      });
+
+      stream.on('data', function(data) {
+        if(data.results[0] && data.results[0].final) {
+          stream.stop();
+          console.log('stop listening.');
+        }
       });
 
       stream.on('error', function(err) {

--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -24,7 +24,6 @@ var contentType = require('./content-type');
 var qs = require('../util/querystring.js');
 
 var OPENING_MESSAGE_PARAMS_ALLOWED = [
-  'continuous',
   'inactivity_timeout',
   'timestamps',
   'word_confidence',
@@ -58,7 +57,6 @@ var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'X-Wats
  * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
  * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, and ogg/opus are supported
  * @param {Boolean} [options.interim_results=true] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
- * @param {Boolean} [options.continuous=true] - set to false to automatically stop the transcription after the first "sentence"
  * @param {Boolean} [options.word_confidence=false] - include confidence scores with results. Defaults to true when in objectMode.
  * @param {Boolean} [options.timestamps=false] - include timestamps with results. Defaults to true when in objectMode.
  * @param {Number} [options.max_alternatives=1] - maximum number of alternative transcriptions to include. Defaults to 3 when in objectMode.
@@ -66,7 +64,7 @@ var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'X-Wats
  * @param {Number} [options.keywords_threshold] - Number between 0 and 1 representing the minimum confidence before including a keyword in the results. Required when options.keywords is set
  * @param {Number} [options.word_alternatives_threshold] - Number between 0 and 1 representing the minimum confidence before including an alternative word in the results. Must be set to enable word alternatives,
  * @param {Boolean} [options.profanity_filter=false] - set to true to filter out profanity and replace the words with *'s
- * @param {Number} [options.inactivity_timeout=30] - how many seconds of silence before automatically closing the stream (even if continuous is true). use -1 for infinity
+ * @param {Number} [options.inactivity_timeout=30] - how many seconds of silence before automatically closing the stream. use -1 for infinity
  * @param {Boolean} [options.readableObjectMode=false] - emit `result` objects instead of string Buffers for the `data` events. Does not affect input (which must be binary)
  * @param {Boolean} [options.objectMode=false] - alias for options.readableObjectMode
  * @param {Number} [options.X-Watson-Learning-Opt-Out=false] - set to true to opt-out of allowing Watson to use this request to improve it's services


### PR DESCRIPTION
Remove continuous flag that is no longer supported

- [x ] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x ] readme and/or JSDoc is updated
