### PR TITLE
removed continuous parameter from all remaining speech-to-text code/examples

### DIFF
--- a/examples/static/browserify-app.js
+++ b/examples/static/browserify-app.js
@@ -16,7 +16,6 @@ document.querySelector('#button').onclick = function() {
     .then(function(token) {
       var stream = recognizeMicrophone({
         token: token,
-        continuous: false, // false = automatically stop transcription the first time a pause is detected
         outputElement: '#output' // CSS selector or DOM Element
       });
 

--- a/examples/static/microphone-streaming-auto-stop.html
+++ b/examples/static/microphone-streaming-auto-stop.html
@@ -34,7 +34,6 @@ document.querySelector('#button').onclick = function () {
 
       var stream = WatsonSpeech.SpeechToText.recognizeMicrophone({
         token: token,
-//        continuous: false, // no longer supported
         outputElement: '#output' // CSS selector or DOM Element
       });
 

--- a/examples/static/webpack-app.js
+++ b/examples/static/webpack-app.js
@@ -16,7 +16,6 @@ document.querySelector('#button').onclick = function() {
     .then(function(token) {
       var stream = recognizeMicrophone({
         token: token,
-        continuous: false, // false = automatically stop transcription the first time a pause is detected
         outputElement: '#output' // CSS selector or DOM Element
       });
 

--- a/speech-to-text/recognize-file.js
+++ b/speech-to-text/recognize-file.js
@@ -91,7 +91,6 @@ module.exports = function recognizeFile(options) {
 
   var rsOpts = assign(
     {
-      continuous: true,
       interim_results: true
     },
     options

--- a/speech-to-text/recognize-microphone.js
+++ b/speech-to-text/recognize-microphone.js
@@ -82,7 +82,6 @@ module.exports = function recognizeMicrophone(options) {
 
   var rsOpts = assign(
     {
-      continuous: true,
       'content-type': 'audio/l16;rate=16000',
       interim_results: true
     },
@@ -166,7 +165,7 @@ module.exports = function recognizeMicrophone(options) {
         l16Stream.end();
       }
       // trigger on both stop and end events:
-      // stop will not fire when a stream ends due to a timeout or having continuous: false
+      // stop will not fire when a stream ends due to a timeout
       // but when stop does fire, we want to honor it immediately
       // end will always fire, but it may take a few moments after stop
       if (keepMic) {


### PR DESCRIPTION
The `continuous` parameter was removed from the speech-to-text API last month. I found remnants of this parameter being specified in a few places. 

This PR removes these references.
