### PR TITLE
Added webm to headerContentTypes 

### DIFF
--- a/dist/watson-speech.js
+++ b/dist/watson-speech.js
@@ -4480,7 +4480,7 @@ var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'X-Wats
  * @param {String} [options.url='wss://stream.watsonplatform.net/speech-to-text/api'] base URL for service
  * @param {String} [options.token] - Auth token
  * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
- * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, and ogg/opus are supported
+ * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, ogg/opus, and webm are supported
  * @param {Boolean} [options.interim_results=true] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
  * @param {Boolean} [options.word_confidence=false] - include confidence scores with results. Defaults to true when in objectMode.
  * @param {Boolean} [options.timestamps=false] - include timestamps with results. Defaults to true when in objectMode.

--- a/speech-to-text/content-type.js
+++ b/speech-to-text/content-type.js
@@ -12,7 +12,8 @@ var headerContentTypes = {
   fLaC: 'audio/flac',
   RIFF: 'audio/wav',
   OggS: 'audio/ogg',
-  ID3: 'audio/mp3'
+  ID3: 'audio/mp3',
+  '\u001aEߣ': 'audio/webm' // String for first four hex's of webm: [1A][45][DF][A3] (https://www.matroska.org/technical/specs/index.html#EBML)
 };
 
 /**

--- a/speech-to-text/file-player.js
+++ b/speech-to-text/file-player.js
@@ -66,7 +66,7 @@ function getContentTypeFromFile(file) {
       if (ct) {
         resolve(ct);
       } else {
-        var err = new Error('Unable to determine content type from file header; only wav, flac, ogg/opus, and webm are supported.');
+        var err = new Error('Unable to determine content type from file header. Supported file types: wav, mp3, flac, ogg, and webm.');
         err.name = FilePlayer.ERROR_UNSUPPORTED_FORMAT;
         reject(err);
       }

--- a/speech-to-text/file-player.js
+++ b/speech-to-text/file-player.js
@@ -66,7 +66,7 @@ function getContentTypeFromFile(file) {
       if (ct) {
         resolve(ct);
       } else {
-        var err = new Error('Unable to determine content type from file header; only wav, flac, and ogg/opus are supported.');
+        var err = new Error('Unable to determine content type from file header; only wav, flac, ogg/opus, and webm are supported.');
         err.name = FilePlayer.ERROR_UNSUPPORTED_FORMAT;
         reject(err);
       }

--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -55,7 +55,7 @@ var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'X-Wats
  * @param {String} [options.url='wss://stream.watsonplatform.net/speech-to-text/api'] base URL for service
  * @param {String} [options.token] - Auth token
  * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
- * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, and ogg/opus are supported
+ * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, ogg/opus, and webm are supported
  * @param {Boolean} [options.interim_results=true] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
  * @param {Boolean} [options.word_confidence=false] - include confidence scores with results. Defaults to true when in objectMode.
  * @param {Boolean} [options.timestamps=false] - include timestamps with results. Defaults to true when in objectMode.


### PR DESCRIPTION
Added webm to headerContentTypes as was previously missing in content-types.js

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] readme and/or JSDoc is updated
