### PR TITLE
provide an option for access_token

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,11 @@ See a more advanced example at https://speech-to-text-demo.mybluemix.net/
 All API methods require an auth token that must be [generated server-side](https://github.com/watson-developer-cloud/node-sdk#authorization). 
 (See https://github.com/watson-developer-cloud/speech-javascript-sdk/tree/master/examples/ for a couple of basic examples in Node.js and Python.)
 
+_NOTE_: The `token` parameter only works for CF instances of services. For RC services using IAM for authentication, the `access_token` parameter must be used.
+
 ## [`WatsonSpeech.TextToSpeech`](http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_text-to-speech.html)
 
-### [`.synthesize({text, token})`](http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_text-to-speech_synthesize.html) -> `<audio>`
+### [`.synthesize({text, token||access_token})`](http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_text-to-speech_synthesize.html) -> `<audio>`
 
 Speaks the supplied text through an automatically-created `<audio>` element. 
 Currently limited to text that can fit within a GET URL (this is particularly an issue on [Internet Explorer before Windows 10](http://stackoverflow.com/questions/32267442/url-length-limitation-of-microsoft-edge)
@@ -80,7 +82,7 @@ The `recognizeMicrophone()` and `recognizeFile()` helper methods are recommended
 
 The core of the library is the [RecognizeStream] that performs the actual transcription, and a collection of other Node.js-style streams that manipulate the data in various ways. For less common use-cases, the core components may be used directly with the helper methods serving as optional templates to follow. The full library is documented at http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_speech-to-text.html
 
-### [`.recognizeMicrophone({token})`](http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_speech-to-text_recognize-microphone.html) -> Stream
+### [`.recognizeMicrophone({token||access_token})`](http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_speech-to-text_recognize-microphone.html) -> Stream
 
 Options: 
 * `keepMicrophone`: if true, preserves the MicrophoneStream for subsequent calls, preventing additional permissions requests in Firefox
@@ -96,7 +98,7 @@ Also note that Chrome requires https (with a few exceptions for localhost and su
 No more data will be set after `.stop()` is called on the returned stream, but additional results may be recieved for already-sent data.
 
 
-### [`.recognizeFile({data, token})`](http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_speech-to-text_recognize-file.html) -> Stream
+### [`.recognizeFile({data, token||access_token})`](http://watson-developer-cloud.github.io/speech-javascript-sdk/master/module-watson-speech_speech-to-text_recognize-file.html) -> Stream
 
 Can recognize and optionally attempt to play a URL, [File](https://developer.mozilla.org/en-US/docs/Web/API/File) or [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob)
 (such as from an `<input type="file"/>` or from an ajax request.)

--- a/speech-to-text/get-models.js
+++ b/speech-to-text/get-models.js
@@ -37,12 +37,13 @@
 
  * @todo define format in @return statement
  * @param {Object} options
- * @param {String} options.token auth token
+ * @param {String} options.token auth token for CF services
+ * @param {String} options.access_token IAM access token for RC services
  * @return {Promise.<T>}
  */
 module.exports = function getModels(options) {
-  if (!options || !options.token) {
-    throw new Error('Watson SpeechToText: missing required parameter: options.token');
+  if (!options || !options.token || !options.access_token) {
+    throw new Error('Watson SpeechToText: missing required auth parameter: options.token (CF) or options.access_token (RC)');
   }
   var reqOpts = {
     credentials: 'omit',
@@ -50,7 +51,13 @@ module.exports = function getModels(options) {
       accept: 'application/json'
     }
   };
-  return fetch('https://stream.watsonplatform.net/speech-to-text/api/v1/models?watson-token=' + options.token, reqOpts)
+  var url;
+  if (options.access_token) {
+    url = 'https://stream.watsonplatform.net/speech-to-text/api/v1/models?access_token=' + options.access_token;
+  } else {
+    url = 'https://stream.watsonplatform.net/speech-to-text/api/v1/models?watson-token=' + options.token;
+  }
+  return fetch(url, reqOpts)
     .then(function(response) {
       return response.json();
     })

--- a/speech-to-text/get-models.js
+++ b/speech-to-text/get-models.js
@@ -42,7 +42,7 @@
  * @return {Promise.<T>}
  */
 module.exports = function getModels(options) {
-  if (!options || !options.token || !options.access_token) {
+  if (!options || (!options.token && !options.access_token)) {
     throw new Error('Watson SpeechToText: missing required auth parameter: options.token (CF) or options.access_token (RC)');
   }
   var reqOpts = {

--- a/speech-to-text/recognize-file.js
+++ b/speech-to-text/recognize-file.js
@@ -50,7 +50,7 @@ var fetch = require('nodeify-fetch'); // like regular fetch, but with an extra m
  */
 module.exports = function recognizeFile(options) {
   // eslint-disable-line complexity
-  if (!options || !options.token || !options.access_token) {
+  if (!options || (!options.token && !options.access_token)) {
     throw new Error('WatsonSpeechToText: missing required parameter: opts.token (CF) or opts.access_token (RC)');
   }
 

--- a/speech-to-text/recognize-file.js
+++ b/speech-to-text/recognize-file.js
@@ -36,7 +36,8 @@ var fetch = require('nodeify-fetch'); // like regular fetch, but with an extra m
  * (e.g. from a file <input>, a dragdrop target, or an ajax request)
  *
  * @param {Object} options - Also passed to {MediaElementAudioStream} and to {RecognizeStream}
- * @param {String} options.token - Auth Token - see https://github.com/watson-developer-cloud/node-sdk#authorization
+ * @param {String} options.token - Auth Token for CF services - see https://github.com/watson-developer-cloud/node-sdk#authorization
+ * @param {String} options.access_token - IAM Access Token for RC services - see https://github.com/watson-developer-cloud/node-sdk#authorization
  * @param {Blob|FileString} options.file - String url or the raw audio data as a Blob or File instance to be transcribed (and optionally played). Playback may not with with Blob or File on mobile Safari.
  * @param {Boolean} [options.play=false] - If a file is set, play it locally as it's being uploaded
  * @param {Boolena} [options.format=true] - pipe the text through a {FormatStream} which performs light formatting. Also controls smart_formatting option unless explicitly set.
@@ -49,8 +50,8 @@ var fetch = require('nodeify-fetch'); // like regular fetch, but with an extra m
  */
 module.exports = function recognizeFile(options) {
   // eslint-disable-line complexity
-  if (!options || !options.token) {
-    throw new Error('WatsonSpeechToText: missing required parameter: opts.token');
+  if (!options || !options.token || !options.access_token) {
+    throw new Error('WatsonSpeechToText: missing required parameter: opts.token (CF) or opts.access_token (RC)');
   }
 
   if (options.data && !options.file) {

--- a/speech-to-text/recognize-microphone.js
+++ b/speech-to-text/recognize-microphone.js
@@ -56,7 +56,7 @@ var bitBucket = new Writable({
  * @return {RecognizeStream|SpeakerStream|FormatStream|ResultStream}
  */
 module.exports = function recognizeMicrophone(options) {
-  if (!options || !options.token || !options.access_token) {
+  if (!options || (!options.token && !options.access_token)) {
     throw new Error('WatsonSpeechToText: missing required parameter: opts.token (CF) or opts.access_token (RC)');
   }
 

--- a/speech-to-text/recognize-microphone.js
+++ b/speech-to-text/recognize-microphone.js
@@ -44,7 +44,8 @@ var bitBucket = new Writable({
  * Create and return a RecognizeStream sourcing audio from the user's microphone
  *
  * @param {Object} options - Also passed to {RecognizeStream}, and {FormatStream} when applicable
- * @param {String} options.token - Auth Token - see https://github.com/watson-developer-cloud/node-sdk#authorization
+ * @param {String} options.token - Auth Token for CF services - see https://github.com/watson-developer-cloud/node-sdk#authorization
+ * @param {String} options.access_token - IAM Access Token for RC services - see https://github.com/watson-developer-cloud/node-sdk#authorization
  * @param {Boolean} [options.format=true] - pipe the text through a FormatStream which performs light formatting. Also controls smart_formatting option unless explicitly set.
  * @param {Boolean} [options.keepMicrophone=false] - keeps an internal reference to the microphone stream to reuse in subsequent calls (prevents multiple permissions dialogs in firefox)
  * @param {String|DOMElement} [options.outputElement] pipe the text to a [WriteableElementStream](WritableElementStream.html) targeting the specified element. Also defaults objectMode to true to enable interim results.
@@ -55,8 +56,8 @@ var bitBucket = new Writable({
  * @return {RecognizeStream|SpeakerStream|FormatStream|ResultStream}
  */
 module.exports = function recognizeMicrophone(options) {
-  if (!options || !options.token) {
-    throw new Error('WatsonSpeechToText: missing required parameter: opts.token');
+  if (!options || !options.token || !options.access_token) {
+    throw new Error('WatsonSpeechToText: missing required parameter: opts.token (CF) or opts.access_token (RC)');
   }
 
   // the WritableElementStream works best in objectMode

--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -38,7 +38,7 @@ var OPENING_MESSAGE_PARAMS_ALLOWED = [
   'speaker_labels'
 ];
 
-var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'X-Watson-Learning-Opt-Out'];
+var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'access_token', 'X-Watson-Learning-Opt-Out'];
 
 /**
  * pipe()-able Node.js Duplex stream - accepts binary audio and emits text/objects in it's `data` events.
@@ -53,7 +53,8 @@ var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'X-Wats
  * @param {Object} options
  * @param {String} [options.model='en-US_BroadbandModel'] - voice model to use. Microphone streaming only supports broadband models.
  * @param {String} [options.url='wss://stream.watsonplatform.net/speech-to-text/api'] base URL for service
- * @param {String} [options.token] - Auth token
+ * @param {String} [options.token] - Auth token for CF services
+ * @param {String} options.access_token - IAM Access Token for RC services
  * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
  * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, ogg/opus, and webm are supported
  * @param {Boolean} [options.interim_results=true] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.

--- a/text-to-speech/get-voices.js
+++ b/text-to-speech/get-voices.js
@@ -43,7 +43,7 @@
  * @return {Promise.<T>}
  */
 module.exports = function getVoices(options) {
-  if (!options || !options.token || !options.access_token) {
+  if (!options || (!options.token && !options.access_token)) {
     throw new Error('Watson TextToSpeech: missing required auth parameter: options.token (CF) or options.access_token (RC)');
   }
   var reqOpts = {

--- a/text-to-speech/get-voices.js
+++ b/text-to-speech/get-voices.js
@@ -38,12 +38,13 @@
 
  * @todo define format in @return statement
  * @param {Object} options
- * @param {String} options.token auth token
+ * @param {String} options.token auth token for CF services
+ * @param {String} options.access_token IAM access token for RC services
  * @return {Promise.<T>}
  */
 module.exports = function getVoices(options) {
-  if (!options || !options.token) {
-    throw new Error('Watson TextToSpeech: missing required parameter: options.token');
+  if (!options || !options.token || !options.access_token) {
+    throw new Error('Watson TextToSpeech: missing required auth parameter: options.token (CF) or options.access_token (RC)');
   }
   var reqOpts = {
     credentials: 'omit',
@@ -51,7 +52,13 @@ module.exports = function getVoices(options) {
       accept: 'application/json'
     }
   };
-  return fetch('https://stream.watsonplatform.net/text-to-speech/api/v1/voices?watson-token=' + options.token, reqOpts)
+  var url;
+  if (options.access_token) {
+    url = 'https://stream.watsonplatform.net/text-to-speech/api/v1/voices?watson-token=' + options.access_token;
+  } else {
+    url = 'https://stream.watsonplatform.net/text-to-speech/api/v1/voices?watson-token=' + options.token;
+  }
+  return fetch(url, reqOpts)
     .then(function(response) {
       return response.json();
     })

--- a/text-to-speech/synthesize.js
+++ b/text-to-speech/synthesize.js
@@ -29,7 +29,8 @@ var QUERY_PARAMS_ALLOWED = ['voice', 'X-WDC-PL-OPT-OUT', 'X-Watson-Learning-Opt-
  * Creates and returns a HTML5 `<audio>` element
  *
  * @param {Object} options
- * @param {String} options.token auth token
+ * @param {String} [options.token] - Auth token for CF services
+ * @param {String} options.access_token - IAM Access Token for RC services
  * @param {String} options.text text to speak
  * @param {String} [options.voice=en-US_MichaelVoice] what voice to use - call getVoices() for a complete list.
  * @param {String} [options.customization_id] GUID of a custom voice model. Omit to use the voice with no customization.
@@ -42,7 +43,7 @@ var QUERY_PARAMS_ALLOWED = ['voice', 'X-WDC-PL-OPT-OUT', 'X-Watson-Learning-Opt-
  */
 module.exports = function synthesize(options) {
   if (!options || !options.token) {
-    throw new Error('Watson TextToSpeech: missing required parameter: options.token');
+    throw new Error('Watson TextToSpeech: missing required parameter: options.token (CF) or options.access_token (RC)');
   }
   options['watson-token'] = options.token;
   delete options.token;

--- a/text-to-speech/synthesize.js
+++ b/text-to-speech/synthesize.js
@@ -42,7 +42,7 @@ var QUERY_PARAMS_ALLOWED = ['voice', 'X-WDC-PL-OPT-OUT', 'X-Watson-Learning-Opt-
  * @see module:watson-speech/text-to-speech/get-voices
  */
 module.exports = function synthesize(options) {
-  if (!options || !options.token) {
+  if (!options || (!options.token && !options.access_token)) {
     throw new Error('Watson TextToSpeech: missing required parameter: options.token (CF) or options.access_token (RC)');
   }
   options['watson-token'] = options.token;

--- a/util/querystring.js
+++ b/util/querystring.js
@@ -13,7 +13,7 @@
 exports.stringify = function stringify(queryParams) {
   return Object.keys(queryParams)
     .map(function(key) {
-      return key + '=' + (key === 'watson-token' ? queryParams[key] : encodeURIComponent(queryParams[key])); // the server chokes if the token is correctly url-encoded
+      return key + '=' + (key === 'watson-token' || key === 'access_token' ? queryParams[key] : encodeURIComponent(queryParams[key])); // the server chokes if the token is correctly url-encoded
     })
     .join('&');
 };


### PR DESCRIPTION
I implemented this a bit differently than I did in the Node SDK, because in this code we don’t have a built-in way of knowing if the service is using IAM or not. 

So, what I did was leave the `watson-token` code untouched and simply added a new option, `access_token`, that the user will have to intentionally provide if they ware using IAM. I updated the code to handle this and updated the documentation. Let me know what you think about this change. I can also update my PR in the Node SDK to match what I did here if you would prefer.

Currently, tests are failing. Not sure why but I will update this PR accordingly when I find out.

UPDATE: Tests are now passing. Have not added any new tests.

##### Checklist
- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [x] readme and/or JSDoc is updated
