### PR TITLE
add support for acoustic_customization_id

### DIFF
--- a/speech-to-text/recognize-microphone.js
+++ b/speech-to-text/recognize-microphone.js
@@ -108,19 +108,17 @@ module.exports = function recognizeMicrophone(options) {
       bufferSize: options.bufferSize
     });
     var pm = options.mediaStream ? Promise.resolve(options.mediaStream) : getUserMedia({ video: false, audio: true });
-    pm
-      .then(function(mediaStream) {
-        micStream.setStream(mediaStream);
-        if (keepMic) {
-          preservedMicStream = micStream;
-        }
-      })
-      .catch(function(err) {
-        stream.emit('error', err);
-        if (err.name === 'NotSupportedError') {
-          stream.end(); // end the stream
-        }
-      });
+    pm.then(function(mediaStream) {
+      micStream.setStream(mediaStream);
+      if (keepMic) {
+        preservedMicStream = micStream;
+      }
+    }).catch(function(err) {
+      stream.emit('error', err);
+      if (err.name === 'NotSupportedError') {
+        stream.end(); // end the stream
+      }
+    });
   }
 
   var l16Stream = new L16({ writableObjectMode: true });

--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -38,7 +38,7 @@ var OPENING_MESSAGE_PARAMS_ALLOWED = [
   'speaker_labels'
 ];
 
-var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'access_token', 'X-Watson-Learning-Opt-Out'];
+var QUERY_PARAMS_ALLOWED = ['customization_id', 'acoustic_customization_id', 'model', 'watson-token', 'access_token', 'X-Watson-Learning-Opt-Out'];
 
 /**
  * pipe()-able Node.js Duplex stream - accepts binary audio and emits text/objects in it's `data` events.
@@ -71,6 +71,7 @@ var QUERY_PARAMS_ALLOWED = ['customization_id', 'model', 'watson-token', 'access
  * @param {Number} [options.X-Watson-Learning-Opt-Out=false] - set to true to opt-out of allowing Watson to use this request to improve it's services
  * @param {Boolean} [options.smart_formatting=false] - formats numeric values such as dates, times, currency, etc.
  * @param {String} [options.customization_id] - Customization ID
+ * @param {String} [options.acoustic_customization_id] - Acoustic customization ID
  *
  * @constructor
  */


### PR DESCRIPTION
<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->

Hello,

This PR will introduce the ability to pass an acoustic_customization_id.
https://www.ibm.com/watson/developercloud/speech-to-text/api/v1/curl.html?curl#websocket_methods

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] tests are included
- [ ] readme and/or JSDoc is updated (JSDoc: yes, README: no)

**CI**

I'm not sure why the CI is failing.