### PR TITLE
docs: fix jsdocs to use correct default for interim_results

### DIFF
--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -57,7 +57,7 @@ var QUERY_PARAMS_ALLOWED = ['customization_id', 'acoustic_customization_id', 'mo
  * @param {String} options.access_token - IAM Access Token for RC services
  * @param {Object} [options.headers] - Only works in Node.js, not in browsers. Allows for custom headers to be set, including an Authorization header (preventing the need for auth tokens)
  * @param {String} [options.content-type='audio/wav'] - content type of audio; can be automatically determined from file header in most cases. only wav, flac, ogg/opus, and webm are supported
- * @param {Boolean} [options.interim_results=true] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
+ * @param {Boolean} [options.interim_results=false] - Send back non-final previews of each "sentence" as it is being processed. These results are ignored in text mode.
  * @param {Boolean} [options.word_confidence=false] - include confidence scores with results.
  * @param {Boolean} [options.timestamps=false] - include timestamps with results.
  * @param {Number} [options.max_alternatives=1] - maximum number of alternative transcriptions to include.


### PR DESCRIPTION
The service default for `interim_results` is `false`, not `true`. Updating the JSDocs.