### PR TITLE
docs: updates .shtml links to new urls

### DIFF
--- a/dist/watson-speech.js
+++ b/dist/watson-speech.js
@@ -4715,7 +4715,7 @@ function FormatStream(opts) {
 }
 util.inherits(FormatStream, Transform);
 
-var reHesitation = /%HESITATION ?/g; // http://www.ibm.com/watson/developercloud/doc/speech-to-text/output.shtml#hesitation - D_ is handled below
+var reHesitation = /%HESITATION ?/g; // https://console.bluemix.net/docs/services/speech-to-text/output.html#output - D_ is handled below
 var reRepeatedCharacter = /([a-z])\1{2,}/gi; // detect the same character repeated three or more times and remove it
 var reDUnderscoreWords = /D_[^\s]+/g; // replace D_(anything)
 

--- a/examples/static/speaker-labels-file-console.html
+++ b/examples/static/speaker-labels-file-console.html
@@ -37,7 +37,7 @@
         file: '/en-us-multi-speaker-narrowband.wav',
         speaker_labels: true,
         // only certain models support speaker labels currently,
-        // see http://www.ibm.com/watson/developercloud/doc/speech-to-text/output.shtml#speaker_labels
+        // see https://console.bluemix.net/docs/services/speech-to-text/output.html#output
         model: 'en-US_NarrowbandModel',
         objectMode: true, // send objects instead of text
         realtime: true, // don't slow down the results if transcription occurs faster than playback

--- a/examples/static/speaker-stream-file-console.html
+++ b/examples/static/speaker-stream-file-console.html
@@ -36,7 +36,7 @@
         token: token,
         file: '/en-us-multi-speaker-narrowband.wav',
         // only certain models support speaker labels currently,
-        // see http://www.ibm.com/watson/developercloud/doc/speech-to-text/output.shtml#speaker_labels
+        // see https://console.bluemix.net/docs/services/speech-to-text/output.html#output
         model: 'en-US_NarrowbandModel',
         resultsBySpeaker: true, // pipes results through a SpeakerStream, and also enables speaker_labels and objectMode
         realtime: false, // don't slow down the results if transcription occurs faster than playback

--- a/examples/static/speaker-stream-file-html.html
+++ b/examples/static/speaker-stream-file-html.html
@@ -39,7 +39,7 @@
         file: '/en-us-multi-speaker-narrowband.wav',
         speaker_labels: true,
         // only certain models support speaker labels currently,
-        // see http://www.ibm.com/watson/developercloud/doc/speech-to-text/output.shtml#speaker_labels
+        // see https://console.bluemix.net/docs/services/speech-to-text/output.html#output
         model: 'en-US_NarrowbandModel',
         resultsBySpeaker: true, // pipes results through a SpeakerStream, and also enables speaker_labels and objectMode
         play: true

--- a/speech-to-text/format-stream.js
+++ b/speech-to-text/format-stream.js
@@ -33,7 +33,7 @@ function FormatStream(opts) {
 }
 util.inherits(FormatStream, Transform);
 
-var reHesitation = /%HESITATION ?/g; // http://www.ibm.com/watson/developercloud/doc/speech-to-text/output.shtml#hesitation - D_ is handled below
+var reHesitation = /%HESITATION ?/g; // https://console.bluemix.net/docs/services/speech-to-text/output.html#output - D_ is handled below
 var reRepeatedCharacter = /([a-z])\1{2,}/gi; // detect the same character repeated three or more times and remove it
 var reDUnderscoreWords = /D_[^\s]+/g; // replace D_(anything)
 


### PR DESCRIPTION
Updates `.shtml` links that would cause redirects if users tried to use them. These links were updated with the correct URL.

Resolves #79 