### PR TITLE
feat: add option for user-provided URL in `synthesize`

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ where the max length is around 1000 characters after the token is accounted for.
 
 Options: 
 * text - the text to speak
+* url - the Watson Text to Speech API URL (defaults to https://stream.watsonplatform.net/text-to-speech/api)
 * voice - the desired playback voice's name - see .getVoices(). Note that the voices are language-specific.
 * customization_id - GUID of a custom voice model - omit to use the voice with no customization.
 * autoPlay - set to false to prevent the audio from automatically playing

--- a/speech-to-text/get-models.js
+++ b/speech-to-text/get-models.js
@@ -54,9 +54,9 @@ module.exports = function getModels(options) {
   };
   var url = options.url || 'https://stream.watsonplatform.net/speech-to-text/api';
   if (options.access_token) {
-    url = url + '/v1/models?access_token=' + options.access_token;
+    url = `${url}/v1/models?access_token=${options.access_token}`;
   } else {
-    url = url + '/v1/models?watson-token=' + options.token;
+    url = `${url}/v1/models?access_token=${options.token}`;
   }
   return fetch(url, reqOpts)
     .then(function(response) {

--- a/speech-to-text/get-models.js
+++ b/speech-to-text/get-models.js
@@ -37,6 +37,7 @@
 
  * @todo define format in @return statement
  * @param {Object} options
+ * @param {String} options.url=https://stream.watsonplatform.net/speech-to-text/api URL for Watson Speech to Text API
  * @param {String} options.token auth token for CF services
  * @param {String} options.access_token IAM access token for RC services
  * @return {Promise.<T>}
@@ -51,11 +52,11 @@ module.exports = function getModels(options) {
       accept: 'application/json'
     }
   };
-  var url;
+  var url = options.url || 'https://stream.watsonplatform.net/speech-to-text/api';
   if (options.access_token) {
-    url = 'https://stream.watsonplatform.net/speech-to-text/api/v1/models?access_token=' + options.access_token;
+    url = url + '/v1/models?access_token=' + options.access_token;
   } else {
-    url = 'https://stream.watsonplatform.net/speech-to-text/api/v1/models?watson-token=' + options.token;
+    url = url + '/v1/models?watson-token=' + options.token;
   }
   return fetch(url, reqOpts)
     .then(function(response) {

--- a/text-to-speech/get-voices.js
+++ b/text-to-speech/get-voices.js
@@ -55,9 +55,9 @@ module.exports = function getVoices(options) {
   };
   var url = options.url || 'https://stream.watsonplatform.net/text-to-speech/api';
   if (options.access_token) {
-    url = url + '/v1/voices?watson-token=' + options.access_token;
+    url = `${url}'/v1/voices?watson-token='${options.access_token}`;
   } else {
-    url = url + '/v1/voices?watson-token=' + options.token;
+    url = `${url}'/v1/voices?watson-token='${options.token}`;
   }
   return fetch(url, reqOpts)
     .then(function(response) {

--- a/text-to-speech/get-voices.js
+++ b/text-to-speech/get-voices.js
@@ -38,6 +38,7 @@
 
  * @todo define format in @return statement
  * @param {Object} options
+ * @param {String} options.url=https://stream.watsonplatform.net/text-to-speech/api URL for Watson Text to Speech API
  * @param {String} options.token auth token for CF services
  * @param {String} options.access_token IAM access token for RC services
  * @return {Promise.<T>}
@@ -52,11 +53,11 @@ module.exports = function getVoices(options) {
       accept: 'application/json'
     }
   };
-  var url;
+  var url = options.url || 'https://stream.watsonplatform.net/text-to-speech/api';
   if (options.access_token) {
-    url = 'https://stream.watsonplatform.net/text-to-speech/api/v1/voices?watson-token=' + options.access_token;
+    url = url + '/v1/voices?watson-token=' + options.access_token;
   } else {
-    url = 'https://stream.watsonplatform.net/text-to-speech/api/v1/voices?watson-token=' + options.token;
+    url = url + '/v1/voices?watson-token=' + options.token;
   }
   return fetch(url, reqOpts)
     .then(function(response) {

--- a/text-to-speech/synthesize.js
+++ b/text-to-speech/synthesize.js
@@ -51,7 +51,7 @@ module.exports = function synthesize(options) {
   var url = options.url || 'https://stream.watsonplatform.net/text-to-speech/api';
   var audio = options.element || new Audio();
   audio.crossOrigin = 'anonymous';
-  audio.src = url + '/v1/synthesize?' + qs.stringify(pick(options, QUERY_PARAMS_ALLOWED));
+  audio.src = `${url}/v1/synthesize?${qs.stringify(pick(options, QUERY_PARAMS_ALLOWED))}`;
   if (options.autoPlay !== false) {
     audio.play();
   }

--- a/text-to-speech/synthesize.js
+++ b/text-to-speech/synthesize.js
@@ -29,6 +29,7 @@ var QUERY_PARAMS_ALLOWED = ['voice', 'X-WDC-PL-OPT-OUT', 'X-Watson-Learning-Opt-
  * Creates and returns a HTML5 `<audio>` element
  *
  * @param {Object} options
+ * @param {String} options.url=https://stream.watsonplatform.net/text-to-speech/api URL for Watson Text to Speech API
  * @param {String} [options.token] - Auth token for CF services
  * @param {String} options.access_token - IAM Access Token for RC services
  * @param {String} options.text text to speak
@@ -47,9 +48,10 @@ module.exports = function synthesize(options) {
   }
   options['watson-token'] = options.token;
   delete options.token;
+  var url = options.url || 'https://stream.watsonplatform.net/text-to-speech/api';
   var audio = options.element || new Audio();
   audio.crossOrigin = 'anonymous';
-  audio.src = 'https://stream.watsonplatform.net/text-to-speech/api/v1/synthesize?' + qs.stringify(pick(options, QUERY_PARAMS_ALLOWED));
+  audio.src = url + '/v1/synthesize?' + qs.stringify(pick(options, QUERY_PARAMS_ALLOWED));
   if (options.autoPlay !== false) {
     audio.play();
   }


### PR DESCRIPTION
Added an option for user to provide their own URL everywhere it seemed appropriate:
- text-to-speech/synthesize
- text-to-speech/getVoices
- speech-to-text/getModels

Updated the JSDocs and README.