### PR TITLE
Synthesize method does not honor access_token from IAM API Key

### DIFF
--- a/dist/watson-speech.js
+++ b/dist/watson-speech.js
@@ -12124,7 +12124,7 @@ exports.getVoices = __webpack_require__(84);
 var pick = __webpack_require__(30);
 var qs = __webpack_require__(31);
 
-var QUERY_PARAMS_ALLOWED = ['voice', 'X-WDC-PL-OPT-OUT', 'X-Watson-Learning-Opt-Out', 'text', 'watson-token', 'accept', 'customization_id'];
+var QUERY_PARAMS_ALLOWED = ['voice', 'X-WDC-PL-OPT-OUT', 'X-Watson-Learning-Opt-Out', 'text', 'watson-token', 'accept', 'customization_id', 'access_token'];
 
 /**
  * @module watson-speech/text-to-speech/synthesize
@@ -12152,8 +12152,12 @@ module.exports = function synthesize(options) {
   if (!options || (!options.token && !options.access_token)) {
     throw new Error('Watson TextToSpeech: missing required parameter: options.token (CF) or options.access_token (RC)');
   }
-  options['watson-token'] = options.token;
-  delete options.token;
+  
+  if(options.token) {
+    options['watson-token'] = options.token;
+    delete options.token;
+  }
+  
   var audio = options.element || new Audio();
   audio.crossOrigin = 'anonymous';
   audio.src = 'https://stream.watsonplatform.net/text-to-speech/api/v1/synthesize?' + qs.stringify(pick(options, QUERY_PARAMS_ALLOWED));


### PR DESCRIPTION
In SDK v.0.36 with Firefox 60.3.0esr (64-bit), using the new IAM API Key authentication for Text to Speech, the synthesize method filters out the access_token parameter.

```
var params = {
  text: "Hello",
  voice: "en-US_MichaelVoice",
  access_token: "<ACCESS_TOKEN>"
};

stream = WatsonSpeech.TextToSpeech.synthesize(params);
```

The requested URI resource doesn't include this access token and the watson-token parameter is undefined, returning a CORS error.
```
https://stream.watsonplatform.net/text-to-speech/api/v1/synthesize?voice=en-US_MichaelVoice&text=Hello&watson-token=**undefined**
```

---

There should also be a check that token parameter is defined, given it's either token or access_token. 

```
module.exports = function synthesize(options) {
  if (!options || (!options.token && !options.access_token)) {
    throw new Error('Watson TextToSpeech: missing required parameter: options.token (CF) or options.access_token (RC)');
  }
  options['watson-token'] = options.token;
  delete options.token;
  var audio = options.element || new Audio();
```

##### Checklist

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
