### PR TITLE
docs: add readme section about iam

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ This method enables a smaller bundle by only including the desired components, f
 var recognizeMic = require('watson-speech/speech-to-text/recognize-microphone');
 ```
 
+## Using with IAM
+
+This SDK _CAN_ be used in the browser with services that use IAM for authentication. This does require a server-side component - an endpoint used to retrieve the token. An example can be found [here](https://github.com/watson-developer-cloud/speech-javascript-sdk/blob/master/examples/server.js#L92).
+
+Once that is set up, the token can be used in your SDK request with the parameter `access_token`. See [this example](https://github.com/watson-developer-cloud/speech-javascript-sdk/blob/master/examples/static/microphone-streaming.html#L36).
 
 ## Changes
 


### PR DESCRIPTION
The IBM docs state that WebSockets cannot be used in the browser with IAM services. This isn't technically correct - the token can't be retrieved from the browser but WebSockets can still be used in the browser with a valid token. I get support issues dealing with this all of the time, so I added this section to the README detailing how to do it. I'm still working on getting that statement removed from the docs.