### PR TITLE
chore: revert change to specific version of watson-speech

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -269,7 +269,7 @@
     "@types/form-data": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
-      "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+      "integrity": "sha1-7is7jqoRwJOCiZU2BrdFtzjFSx4=",
       "requires": {
         "@types/node": "*"
       }
@@ -277,7 +277,7 @@
     "@types/is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==",
+      "integrity": "sha1-uE17sgeiEPKvm+1DHcD76cQUO+E=",
       "requires": {
         "@types/node": "*"
       }
@@ -285,12 +285,12 @@
     "@types/node": {
       "version": "10.3.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.3.6.tgz",
-      "integrity": "sha512-h7VDRFL8IhdPw1JjiNVvhr+WynfKW09q2BOflIOA0yeuXNeXBP1bIRuBrysSryH4keaJ5bYUNp63aIyQL9YpDQ=="
+      "integrity": "sha1-6oqrlDm1n0DRnsXxO0RkI0SHKxE="
     },
     "@types/request": {
       "version": "2.47.1",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.47.1.tgz",
-      "integrity": "sha512-TV3XLvDjQbIeVxJ1Z3oCTDk/KuYwwcNKVwz2YaT0F5u86Prgc4syDAp6P96rkTQQ4bIdh+VswQIC9zS6NjY7/g==",
+      "integrity": "sha1-JUENOvvawEyRqUrZ78mCQQBzWCQ=",
       "requires": {
         "@types/caseless": "*",
         "@types/form-data": "*",
@@ -516,7 +516,7 @@
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "integrity": "sha1-jSR136tVO7M+d7VOWeiAu4ziMTY=",
       "requires": {
         "safer-buffer": "~2.1.0"
       }
@@ -615,7 +615,7 @@
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+      "integrity": "sha1-8OAD2cqef1nHpQiUXXsu+aBKVC8="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1277,7 +1277,7 @@
     "combined-stream": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "integrity": "sha1-LR0kMXr7ir6V1tLAsHtXgTU52Cg=",
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -2181,7 +2181,7 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha1-+LETa0Bx+9jrFAr/hYsQGewpFfo="
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -2523,7 +2523,7 @@
     "file-type": {
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-7.7.1.tgz",
-      "integrity": "sha512-bTrKkzzZI6wH+NXhyD3SOXtb2zXTw2SbwI2RxUlRcXVsnN7jNL5hJzVQLYv7FOQhxFkK4XWdAflEaWFpaLLWpQ=="
+      "integrity": "sha1-kcL17bjOcGiLm2ipDZMbu2yyH2U="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2590,7 +2590,7 @@
     "form-data": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "integrity": "sha1-3M5SwF9kTymManq5Nr1yTO/786Y=",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.6",
@@ -5960,7 +5960,7 @@
     "request": {
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "integrity": "sha1-MvACNc0I1IK00NaNuTqCnA7VdW4=",
       "requires": {
         "aws-sign2": "~0.7.0",
         "aws4": "^1.6.0",
@@ -6769,7 +6769,7 @@
     "tough-cookie": {
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
       "requires": {
         "punycode": "^1.4.1"
       }
@@ -7136,7 +7136,7 @@
     "uuid": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "integrity": "sha1-G0r0lV6zB3xQHCOHL8ZROBFYcTE="
     },
     "validate-npm-package-license": {
       "version": "3.0.4",
@@ -7924,7 +7924,7 @@
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-          "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "integrity": "sha1-p0cPnkJnM9gb2B4RVSZOOjUHyrQ=",
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -7932,7 +7932,7 @@
         "object.omit": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-3.0.0.tgz",
-          "integrity": "sha512-EO+BCv6LJfu+gBIF3ggLicFebFLN5zqzz/WWJlMFfkMyGth+oBkhxzDl0wx2W4GkLzuQs/FsSkXZb2IMWQqmBQ==",
+          "integrity": "sha1-Dj7cL84rpU31V3/1KfbZe9ilIq8=",
           "requires": {
             "is-extendable": "^1.0.0"
           }

--- a/examples/package.json
+++ b/examples/package.json
@@ -22,7 +22,7 @@
     "object.assign": "^4.0.4",
     "vcap_services": "^0.4.0",
     "watson-developer-cloud": "3.18.1",
-    "watson-speech": "0.36.0",
+    "watson-speech": "*",
     "webpack": "^3.5.5",
     "webpack-dev-middleware": "^1.10.0",
     "whatwg-fetch": "^2.0.2"


### PR DESCRIPTION
It looked like there was a version 0.36.0 for this package, but there was just a release tag, nothing on NPM. Changing this back to always pull in the latest version.