### PR TITLE
fix: allow exports when using babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,5 +12,6 @@
       "corejs": 3
     }
     ]
-  ]
+  ],
+  "sourceType": "unambiguous"
 }


### PR DESCRIPTION
Resolves #120 

The babel config only supports one kind of export by default. The `sourceType` parameter needs to be set to `unambiguous` in order to use both. More documentation [here](https://babeljs.io/docs/en/options#sourcetype).