### PR TITLE
build: run webpack on travis to catch any build failures during ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
 - export DISPLAY=:99.0
 - sh -e /etc/init.d/xvfb start
 script:
+- npm run build
 - npm test
 - sed -i "s/\/master\//\/$TRAVIS_BRANCH\//g" README.md
 - npm run doc


### PR DESCRIPTION
The tests for this package use the pre-built code. This means it is possible for the tests to pass but the build to fail due to `webpack` errors, etc that aren't necessary due to the code operating incorrectly.

To ensure only build-ready code makes it into the repo, we should run the build step on Travis.