### PR TITLE
Fix live examples

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -89,14 +89,14 @@ var sttAuthService = new AuthorizationV1(
     {
       username: process.env.SPEECH_TO_TEXT_USERNAME, // or hard-code credentials here
       password: process.env.SPEECH_TO_TEXT_PASSWORD,
-      iam_apikey: process.env.SPEECH_TO_TEXT_IAM_APIKEY, // if using an RC service
+      // iam_apikey: process.env.SPEECH_TO_TEXT_IAM_APIKEY, // if using an RC service
       url: process.env.SPEECH_TO_TEXT_URL ? process.env.SPEECH_TO_TEXT_URL : SpeechToTextV1.URL
     },
     vcapServices.getCredentials('speech_to_text') // pulls credentials from environment in bluemix, otherwise returns {}
   )
 );
 app.use('/api/speech-to-text/token', function(req, res) {
-  sttAuthService.getToken({}, function(err, token) {
+  sttAuthService.getToken(function(err, token) {
     if (err) {
       console.log('Error retrieving token: ', err);
       res.status(500).send('Error retrieving token');
@@ -119,7 +119,7 @@ var ttsAuthService = new AuthorizationV1(
   )
 );
 app.use('/api/text-to-speech/token', function(req, res) {
-  ttsAuthService.getToken({}, function(err, token) {
+  ttsAuthService.getToken(function(err, token) {
     if (err) {
       console.log('Error retrieving token: ', err);
       res.status(500).send('Error retrieving token');

--- a/examples/server.js
+++ b/examples/server.js
@@ -89,7 +89,7 @@ var sttAuthService = new AuthorizationV1(
     {
       username: process.env.SPEECH_TO_TEXT_USERNAME, // or hard-code credentials here
       password: process.env.SPEECH_TO_TEXT_PASSWORD,
-      // iam_apikey: process.env.SPEECH_TO_TEXT_IAM_APIKEY, // if using an RC service
+      iam_apikey: process.env.SPEECH_TO_TEXT_IAM_APIKEY, // if using an RC service
       url: process.env.SPEECH_TO_TEXT_URL ? process.env.SPEECH_TO_TEXT_URL : SpeechToTextV1.URL
     },
     vcapServices.getCredentials('speech_to_text') // pulls credentials from environment in bluemix, otherwise returns {}


### PR DESCRIPTION
The Authorization SDK will only use the URL passed into the constructor if a callback is presented as the first argument. An argument could be made that this should change in that SDK but since we are using a constructor-passed URL in the examples, I'm just removing the empty object argument which fixes the problem.

Resolves #124 