### PR TITLE
fix: Chrome autoplay

### DIFF
--- a/text-to-speech/synthesize.js
+++ b/text-to-speech/synthesize.js
@@ -55,7 +55,14 @@ module.exports = function synthesize(options) {
   audio.crossOrigin = 'anonymous';
   audio.src = url + '/v1/synthesize?' + qs.stringify(pick(options, QUERY_PARAMS_ALLOWED));
   if (options.autoPlay !== false) {
-    audio.play();
+    var playPromise = audio.play();
+    if (playPromise !== undefined) {
+      playPromise.then(_ => {
+        // console.log("autoPlay promise resolved")
+      }).catch(error => {
+        throw new Error("Watson TextToSpeech: autoplay error:"+ error)
+      });
+    }
   }
   return audio;
 };

--- a/text-to-speech/synthesize.js
+++ b/text-to-speech/synthesize.js
@@ -57,11 +57,13 @@ module.exports = function synthesize(options) {
   if (options.autoPlay !== false) {
     var playPromise = audio.play();
     if (playPromise !== undefined) {
-      playPromise.then(_ => {
-        // console.log("autoPlay promise resolved")
-      }).catch(error => {
-        throw new Error("Watson TextToSpeech: autoplay error:"+ error)
-      });
+      playPromise
+        .then(() => {
+          // console.log("autoPlay promise resolved")
+        })
+        .catch(error => {
+          throw new Error('Watson TextToSpeech: autoplay error:' + error);
+        });
     }
   }
   return audio;


### PR DESCRIPTION
While using Text-to-speech feature,  google chrome autoplay didn't work. 
This is the exact issue experienced.
https://developers.google.com/web/updates/2017/06/play-request-was-interrupted
<!--
Thank you for your pull request! 

Please provide a description above and review the requirements below.

Bug fixes and new features should include tests whenever possible.
-->
<!--
##### Checklist
-->
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
<!--
- [ ] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [ ] tests are included
- [ ] readme and/or JSDoc is updated
-->