### PR TITLE
feat: allow to add grammar_name parameter to opening message

### DIFF
--- a/speech-to-text/recognize-stream.js
+++ b/speech-to-text/recognize-stream.js
@@ -35,7 +35,8 @@ var OPENING_MESSAGE_PARAMS_ALLOWED = [
   'word_alternatives_threshold',
   'profanity_filter',
   'smart_formatting',
-  'speaker_labels'
+  'speaker_labels',
+  'grammar_name'
 ];
 
 var QUERY_PARAMS_ALLOWED = [
@@ -80,6 +81,7 @@ var QUERY_PARAMS_ALLOWED = [
  * @param {Boolean} [options.smart_formatting=false] - formats numeric values such as dates, times, currency, etc.
  * @param {String} [options.customization_id] - Customization ID
  * @param {String} [options.acoustic_customization_id] - Acoustic customization ID
+ * @param {String} [options.grammar_name] - Name of grammar
  *
  * @constructor
  */


### PR DESCRIPTION
For using a grammar in speech recognition requests to restrict the set of phrases that the service can recognize from audio, I would like to enable to add `grammar_name` to a WebSocket message.
https://cloud.ibm.com/docs/services/speech-to-text?topic=speech-to-text-grammarUse

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes (tip: `npm run autofix` can correct most style issues)
- [x] readme and/or JSDoc is updated